### PR TITLE
fix: CORS with sticky sessions

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -30,6 +30,7 @@ export const useWebsocket = () => {
     const socket = io(process.env.REACT_APP_WSS_URL, {
       reconnectionDelayMax: 10000,
       transports: ['websocket', 'polling'],
+      withCredentials: true,
     })
 
     socket.on('farms', (data) => {


### PR DESCRIPTION
Enabled sticky sessions for load balancing. Tested in local, with local and remote socket.
Reference: https://socket.io/docs/v3/using-multiple-nodes/index.html#Sticky-load-balancing

<img width="558" alt="Screenshot 2021-02-24 at 18 44 39" src="https://user-images.githubusercontent.com/74599990/109042318-5cf88c80-76d0-11eb-86ba-db52c55e4f92.png">